### PR TITLE
More robust escape characters

### DIFF
--- a/textricate.py
+++ b/textricate.py
@@ -13,7 +13,7 @@ see README.md. Requires ftfy.
 from collections import OrderedDict, defaultdict
 import sqlite3
 import time
-import xml.sax.saxutils as saxutils
+from xml.sax import saxutils
 
 from ftfy import fix_encoding
 
@@ -33,10 +33,10 @@ messages = defaultdict(list)  # messages, grouped by time
 # convert from Textra's schema to SMS Backup and Restore's
 for m in db_messages:
     if m['text']:  # filter empty messages
-        text = saxutils.escape(fix_encoding(m['text']), {'"': '&quot;'})  # repair encoding and prepare for XML conversion
+        text = fix_encoding(m['text'])  # repair encoding and prepare for XML conversion
         message = OrderedDict([
             ('protocol', 0),
-            ('address', saxutils.escape(m['lookup_key'].replace('^', ''), {'"': '&quot;'})),
+            ('address', m['lookup_key'].replace('^', '')),
             ('date', m['ts']),
             ('type', m['direction'] + 1),  # Textra uses 0 for received and 1 for sent; SMS B&R uses 1 and 2
             ('subject', 'null'),
@@ -69,7 +69,8 @@ count = len(messages)
 lines = [
     '<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>\n',
     '<smses count="{}" backup_date="{}">\n'.format(count, round(start_time * 1000)),
-    *[' <sms {} />\n'.format(' '.join('{}="{}"'.format(k, v) for k, v in m.items())) for m in messages.values()],
+    *[' <sms {} />\n'.format(' '.join('{}={}'.format(k, saxutils.quoteattr(str(v))) for k, v in m.items()))
+      for m in messages.values()],
     '</smses>'
     ]
 

--- a/textricate.py
+++ b/textricate.py
@@ -13,6 +13,7 @@ see README.md. Requires ftfy.
 from collections import OrderedDict, defaultdict
 import sqlite3
 import time
+import xml.sax.saxutils as saxutils
 
 from ftfy import fix_encoding
 
@@ -32,10 +33,10 @@ messages = defaultdict(list)  # messages, grouped by time
 # convert from Textra's schema to SMS Backup and Restore's
 for m in db_messages:
     if m['text']:  # filter empty messages
-        text = fix_encoding(m['text']).replace('"', '&quot;')  # repair encoding and prepare for XML conversion
+        text = saxutils.escape(fix_encoding(m['text']), {'"': '&quot;'})  # repair encoding and prepare for XML conversion
         message = OrderedDict([
             ('protocol', 0),
-            ('address', m['lookup_key'].replace('^', '')),
+            ('address', saxutils.escape(m['lookup_key'].replace('^', ''), {'"': '&quot;'})),
             ('date', m['ts']),
             ('type', m['direction'] + 1),  # Textra uses 0 for received and 1 for sent; SMS B&R uses 1 and 2
             ('subject', 'null'),


### PR DESCRIPTION
First of all thanks for the helpful script it helps me a lot on converting my textricate database :)

When I first ran your script I had some problem in parsing the result xml, which I later found that some of the characters are not escaped properly.
This PR uses the build in xml escape module to escape characters `&`, `<`, and `>` into `&amp;`, `&lt;`, and `&gt;` respectively (which I was having problem with before).

We couldn't use the `xml.sax.saxutils.quoteattr` to escape the quotes as it will adds a surrounding quotes to the string (see [docs](https://docs.python.org/2/library/xml.sax.utils.html)), therefore the replace is still needed.